### PR TITLE
Feature/stepwise training

### DIFF
--- a/src/fuzzy_coco.cpp
+++ b/src/fuzzy_coco.cpp
@@ -2,6 +2,7 @@
 
 #include "fuzzy_coco.h"
 #include "file_utils.h"
+#include "fuzzy_rule.h"
 #include "logging_logger.h"
 
 using namespace fuzzy_coco;
@@ -22,6 +23,48 @@ FuzzyCoco::FuzzyCoco(const DataFrame& dfin, const DataFrame& dfout, const FuzzyC
     _fitter_ptr(selectFitnessMethods(dfin, dfout, params, _fuzzy_system, *_fuzzy_system_fitter_ptr)),
     _engine(dfin, dfout, *_fitter_ptr, params, rng)
 {}
+
+void FuzzyCoco::resetTrainingState() {
+  _has_active_generation = false;
+  _current_fitness = 0.0;
+}
+
+void FuzzyCoco::init(RandomGenerator& rng, bool influence, double evolving_ratio) {
+  resetTrainingState();
+  _active_generation = start(rng, influence, evolving_ratio);
+  _active_generation.generation_number = 0;
+  _current_fitness = 0.0;
+  _has_active_generation = true;
+
+  getEngine().rebuildBestFuzzySystem();
+  logger() << "initial rules: " << FuzzyRule::describeRules(getFuzzySystem().getRules());
+}
+
+void FuzzyCoco::init(bool influence, double evolving_ratio) {
+  init(getEngine().getRng(), influence, evolving_ratio);
+}
+
+double FuzzyCoco::step() {
+  if (!_has_active_generation) {
+    throw runtime_error("FuzzyCoco::step() called before init()");
+  }
+
+  auto next_gen = getEngine().next(_active_generation);
+  _active_generation = next_gen;
+  _current_fitness = _active_generation.fitness;
+
+  logger() << L_time << "generation " << _active_generation.generation_number
+           << ": fitness=" << _current_fitness << endl;
+  return _current_fitness;
+}
+
+int FuzzyCoco::currentGenerationNumber() const {
+  return _has_active_generation ? _active_generation.generation_number : 0;
+}
+
+double FuzzyCoco::currentFitness() const {
+  return _current_fitness;
+}
 
 unique_ptr<FuzzySystemFitness> 
 FuzzyCoco::selectFuzzySystemFitness(const FuzzyCocoParams& params)
@@ -77,12 +120,38 @@ CoevGeneration FuzzyCoco::run(int nb, double max_fit, bool influence, double evo
 }
 
 CoevGeneration FuzzyCoco::run(int nb, double max_fit, RandomGenerator& rng, bool influence, double evolving_ratio) {
-  auto gen = start(rng, influence, evolving_ratio);
-  return getEngine().run(gen, nb, max_fit);
+  init(rng, influence, evolving_ratio);
+
+  logger() << L_time << "FuzzyCocoEngine::run() " << nb << " generations"
+           << ", max_fit=" << max_fit << endl;
+  for (int i = 0; i < nb; i++) {
+    double fitness = step();
+    if (fitness >= max_fit) break;
+  }
+  logger() << endl;
+
+  return _active_generation;
 }
 
 CoevGeneration FuzzyCoco::run(int nb, double max_fit, CoevGeneration& from_gen) {
-  return getEngine().run(from_gen, nb, max_fit);
+  resetTrainingState();
+  _active_generation = from_gen;
+  _has_active_generation = true;
+  _current_fitness = _active_generation.fitness;
+
+  getEngine().rebuildBestFuzzySystem();
+  logger() << "initial rules: " << FuzzyRule::describeRules(getFuzzySystem().getRules());
+
+  logger() << L_time << "FuzzyCocoEngine::run() " << nb << " generations"
+           << ", max_fit=" << max_fit << endl;
+  for (int i = 0; i < nb; i++) {
+    double fitness = step();
+    if (fitness >= max_fit) break;
+  }
+  logger() << endl;
+
+  from_gen = _active_generation;
+  return from_gen;
 }
 
 NamedList FuzzyCoco::searchBestFuzzySystem(const DataFrame& df, int nb_out_vars, const FuzzyCocoParams& params, int seed)
@@ -226,4 +295,3 @@ void FuzzyCoco::influence_rules_genomes(
     }
   }
 }
-

--- a/src/fuzzy_coco.h
+++ b/src/fuzzy_coco.h
@@ -38,6 +38,11 @@ public:
     return run(p.max_generations, p.max_fitness, p.influence_rules_initial_population, p.influence_evolving_ratio); 
   }
   CoevGeneration run(int nb, double max_fit, CoevGeneration& from_gen);
+  void init(bool influence = false, double evolving_ratio = 0.8);
+  double step();
+  bool hasActiveGeneration() const { return _has_active_generation; }
+  int currentGenerationNumber() const;
+  double currentFitness() const;
 
   NamedList describeBestFuzzySystem() { return getEngine().describeBestFuzzySystem(); }
 
@@ -87,6 +92,12 @@ private:
 
   unique_ptr<FuzzyCocoFitnessMethod> _fitter_ptr;
   FuzzyCocoEngine _engine;
+  CoevGeneration _active_generation;
+  bool _has_active_generation = false;
+  double _current_fitness = 0.0;
+
+  void init(RandomGenerator& rng, bool influence, double evolving_ratio);
+  void resetTrainingState();
 };
 
 }

--- a/tests/unit/fuzzy_coco_test.cpp
+++ b/tests/unit/fuzzy_coco_test.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <stdexcept>
 #include <sstream>
 #include "tests.h"
 #include "fuzzy_coco.h"
@@ -120,6 +121,51 @@ TEST_F(FuzzyCocoTest, run) {
   EXPECT_DOUBLE_EQ(fit, desc.get_double("fitness"));
 }
 
+TEST_F(FuzzyCocoTest, stepwiseMatchesRun) {
+  FuzzyCocoParams params = GET_SAMPLE_PARAMS(DFIN.nbcols());
+  const int nb_generations = 12;
+  const double max_fit = 0.9;
+  params.global_params.max_generations = nb_generations;
+  params.global_params.max_fitness = max_fit;
+
+  RandomGenerator rng_run(12345);
+  FuzzyCoco coco_run(DFIN, DFOUT, params, rng_run);
+  auto gen_run = coco_run.run(nb_generations, max_fit);
+  coco_run.selectBestFuzzySystem();
+  double best_fit_run = coco_run.getFitnessMethod().getBestFitness();
+  auto desc_run = coco_run.getEngine().describeBestFuzzySystem();
+
+  RandomGenerator rng_step(12345);
+  FuzzyCoco coco_step(DFIN, DFOUT, params, rng_step);
+  EXPECT_FALSE(coco_step.hasActiveGeneration());
+  EXPECT_THROW(coco_step.step(), std::runtime_error);
+
+  coco_step.init();
+  EXPECT_TRUE(coco_step.hasActiveGeneration());
+  EXPECT_EQ(coco_step.currentGenerationNumber(), 0);
+  EXPECT_DOUBLE_EQ(coco_step.currentFitness(), 0.0);
+
+  double last_fit = 0.0;
+  int generations_done = 0;
+  for (int i = 0; i < nb_generations; ++i) {
+    last_fit = coco_step.step();
+    ++generations_done;
+    EXPECT_EQ(coco_step.currentGenerationNumber(), generations_done);
+    if (last_fit >= max_fit) break;
+  }
+
+  EXPECT_TRUE(coco_step.hasActiveGeneration());
+  EXPECT_DOUBLE_EQ(coco_step.currentFitness(), last_fit);
+  EXPECT_EQ(coco_step.currentGenerationNumber(), gen_run.generation_number);
+
+  coco_step.selectBestFuzzySystem();
+  double best_fit_step = coco_step.getFitnessMethod().getBestFitness();
+  auto desc_step = coco_step.getEngine().describeBestFuzzySystem();
+
+  EXPECT_DOUBLE_EQ(best_fit_step, best_fit_run);
+  EXPECT_DOUBLE_EQ(desc_step.get_double("fitness"), desc_run.get_double("fitness"));
+}
+
 
 TEST_F(FuzzyCocoTest, searchBestFuzzySystem) {
   FuzzyCocoParams params = GET_SAMPLE_PARAMS(DFIN.nbcols());
@@ -222,5 +268,4 @@ cerr << temp_fuzzy_system << endl;
     remove(temp_fuzzy_system);
   }
 }
-
 


### PR DESCRIPTION
- FuzzyCoco: add stepwise API (init/step) to drive one generation at a time.

- Preserve run(): now delegates to init() + step(), behavior unchanged.

- Minimal state: store active generation + flags

- Add status helpers: hasActiveGeneration(), currentGenerationNumber(), currentFitness().

This was implemented to allow python bindings to control a training iteration per iteration via step

And be able to pull the fitness computation per iteration while keeping a fitness history to monitor training